### PR TITLE
Rename for request to appear on community plugin

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "calibre-opds",
 	"name": "Calibre OPDS Integration",
-	"version": "1.0.0",
+	"version": "1.0.3",
 	"minAppVersion": "0.15.0",
 	"description": "Access, browse & read your books from Calibre locally or remotely via Content Server (Calibre-web & Calibre).",
 	"author": "qvanphong",


### PR DESCRIPTION
# Changes

Calibre-web Obsidian now will be Calibre OPDS Integration, since most early user suggest they would like to access their Calibre library instead of Calibre-web, so I decided to rename the plugin to expand the support to both Calibre-web and Calibre